### PR TITLE
Generate coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
           - wget
     env:
       - MY_ENVIRONMENT="CC=gcc CXX=g++-7"
+      - CODECOV_TOKEN="83bcf4c4-761f-4235-9b11-023a8be02d42"
+
 before_install:
   - wget https://github.com/bazelbuild/bazel/releases/download/2.1.1/bazel_2.1.1-linux-x86_64.deb
   - sudo dpkg -i bazel_2.1.1-linux-x86_64.deb
@@ -24,6 +26,7 @@ before_install:
 install:
   - sudo ln -s /usr/bin/gcc-7 /usr/local/bin/gcc
   - sudo ln -s /usr/bin/g++-7 /usr/local/bin/g++
+
 script:
   - eval "${MY_ENVIRONMENT}"
   - g++ --version
@@ -35,6 +38,9 @@ script:
   - bazel coverage --combined_report=lcov //...
   - genhtml bazel-out/_coverage/_coverage_report.dat --output-directory coverage
   - cd scripts && ./build_for_avr.sh
+
+after_script:
+  - if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then bash <(curl -s https://codecov.io/bash); fi
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,10 @@ script:
   - bazel test //...
   - bazel coverage --combined_report=lcov //...
   - genhtml bazel-out/_coverage/_coverage_report.dat --output-directory coverage
-  - cd scripts && ./build_for_avr.sh
+  - pushd scripts && ./build_for_avr.sh && popd
 
 after_script:
-  - if [[ "$TRAVIS_TEST_RESULT" == 0 ]]; then bash <(curl -s https://codecov.io/bash); fi
+  - pushd scripts && ./push_test_coverage.sh && popd
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 # yamllint disable-line rule:line-length
 
+dist: bionic
+
 matrix:
-  include:
   - os: linux
     addons:
       apt:
@@ -15,13 +16,20 @@ matrix:
           - pkg-config
           - wget
     env:
-      - MY_ENVIRONMENT="CC=clang CXX=clang++"
+      - MY_ENVIRONMENT="CC=gcc CXX=g++-7"
 before_install:
-  - eval "${MY_ENVIRONMENT}"
   - wget https://github.com/bazelbuild/bazel/releases/download/2.1.1/bazel_2.1.1-linux-x86_64.deb
   - sudo dpkg -i bazel_2.1.1-linux-x86_64.deb
 
+install:
+  - sudo ln -s /usr/bin/gcc-7 /usr/local/bin/gcc
+  - sudo ln -s /usr/bin/g++-7 /usr/local/bin/g++
 script:
+  - eval "${MY_ENVIRONMENT}"
+  - g++ --version
+  - gcov --version
+  - lcov --version
+  - bazel --version
   - bazel build //...
   - bazel test //...
   - bazel coverage --combined_report=lcov //...

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ matrix:
           - avr-libc
           - g++-7
           - gcc-avr
+          - lcov
           - pkg-config
           - wget
     env:
@@ -23,6 +24,8 @@ before_install:
 script:
   - bazel build //...
   - bazel test //...
+  - bazel coverage --combined_report=lcov //...
+  - genhtml bazel-out/_coverage/_coverage_report.dat --output-directory coverage
   - cd scripts && ./build_for_avr.sh
 
 env:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-### Containers [![Build Status](https://travis-ci.org/mihaigalos/containers.svg?branch=master)](https://travis-ci.org/mihaigalos/containers) [![license](https://img.shields.io/badge/license-GPLv3-brightgreen.svg)](LICENSE)
+### Containers [![Build Status](https://travis-ci.org/mihaigalos/containers.svg?branch=master)](https://travis-ci.org/mihaigalos/containers) [![codecov](https://codecov.io/gh/mihaigalos/containers/branch/master/graph/badge.svg)](https://codecov.io/gh/mihaigalos/containers) [![license](https://img.shields.io/badge/license-GPLv3-brightgreen.svg)](LICENSE)
 
 Simplified manual C++ implementation of STL containers for devices without one, like AVR / Arduino.
 

--- a/scripts/push_test_coverage.sh
+++ b/scripts/push_test_coverage.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+lcov --list ../bazel-out/_coverage/_coverage_report.dat
+bash <(curl -s https://codecov.io/bash) -f ../bazel-out/_coverage/_coverage_report.dat || echo "Codecov did not collect coverage reports"


### PR DESCRIPTION
```bash
➜  containers git:(interate_test_coverage) ✗ lcov --list bazel-out/_coverage/_coverage_report.dat 
Reading tracefile bazel-out/_coverage/_coverage_report.dat
                                          |Lines       |Functions  |Branches    
Filename                                  |Rate     Num|Rate    Num|Rate     Num
================================================================================
[include/containers/]
dynamic_map.h                             | 100%     34|85.7%    14|    -      0
static_map.h                              | 100%     14| 100%    10|    -      0
static_string.h                           |93.3%     60| 100%    15|    -      0
static_vector.h                           | 100%      4| 100%     6|    -      0

[test/unit/]
test_common.h                             | 100%      2| 100%     1|    -      0
test_dynamic_map_increase_capacity.cpp    | 100%     53|96.7%    30|    -      0
test_maps.cpp                             | 100%     60|97.0%    66|    -      0
test_static_string.cpp                    | 100%     76|98.8%    85|    -      0
test_static_string_size.cpp               | 100%      6| 100%    10|    -      0
test_static_vector.cpp                    | 100%     71|97.6%    42|    -      0
================================================================================
                                    Total:|98.9%    380|97.5%   279|    -      0
```